### PR TITLE
feat: implement `touch` command

### DIFF
--- a/src/cmd_touch.go
+++ b/src/cmd_touch.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// a `touch` command aims to help the user to manage the markdown files.
+// If the file does not exist, it will create a new file with the given title.
+// If the file already exists, it will update the frontmatter fields.
+
+type TouchArgs struct {
+	filepath string
+	title    string
+	path     string
+}
+
+func CreateTouchCmd() *cobra.Command {
+	opts := TouchArgs{}
+	touchCmd := &cobra.Command{
+		Use:           "touch [filepath]",
+		Short:         "create a new markdown file. if the file already exists, update the fields",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		Args:          cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.filepath = args[0]
+			return executeTouch(opts)
+		},
+	}
+	touchCmd.Flags().StringVarP(&opts.title, "title", "t", "", "the title of newly created file")
+	touchCmd.Flags().StringVarP(&opts.path, "path", "p", "", "the URL path of the file")
+	return touchCmd
+}
+
+func executeTouch(args TouchArgs) error {
+	if _, err := os.Stat(args.filepath); os.IsNotExist(err) {
+		return executeTouchNew(args)
+	}
+	return executeTouchUpdate(args)
+}
+
+func executeTouchNew(args TouchArgs) error {
+	file, err := os.Create(args.filepath)
+	if err != nil {
+		return fmt.Errorf("failed to create file: %w", err)
+	}
+	defer file.Close()
+
+	matter := NewFrontMatter(args.title, args.filepath)
+	if _, err := file.WriteString(matter.String()); err != nil {
+		return fmt.Errorf("failed to write front matter: %w", err)
+	}
+	return nil
+}
+
+func executeTouchUpdate(args TouchArgs) error {
+	matter, err := NewFrontMatterFromMarkdown(args.filepath)
+	if err != nil {
+		return err
+	}
+
+	// Update matter
+	if args.title != "" {
+		matter.Title = args.title
+	}
+	if args.path != "" {
+		matter.Path = args.path
+	}
+	matter.UpdatedAt = NewSerializableTimeFromTime(time.Now())
+
+	// Rewrite a markdown
+	return matter.UpdateMarkdown(args.filepath)
+}

--- a/src/main.go
+++ b/src/main.go
@@ -22,5 +22,6 @@ func main() {
 	rootCmd.AddCommand(CreateInitCmd())
 	rootCmd.AddCommand(CreateUploadCmd())
 	rootCmd.AddCommand(CreateVersionCmd())
+	rootCmd.AddCommand(CreateTouchCmd())
 	cobra.CheckErr(rootCmd.Execute())
 }

--- a/src/value_front_matter.go
+++ b/src/value_front_matter.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/adrg/frontmatter"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	FrontMatterStart = "---"
+	FrontMatterEnd   = "---"
+)
+
+// A struct that describe the markdown header.
+type FrontMatter struct {
+	Title     string
+	Path      string
+	CreatedAt SerializableTime
+	UpdatedAt SerializableTime
+}
+
+func NewFrontMatter(title string, path string) *FrontMatter {
+	now := time.Now()
+	return &FrontMatter{
+		Title:     title,
+		Path:      path,
+		CreatedAt: NewSerializableTimeFromTime(now),
+		UpdatedAt: NewSerializableTimeFromTime(now),
+	}
+}
+
+func NewFrontMatterFromMarkdown(filepath string) (*FrontMatter, error) {
+	if _, err := os.Stat(filepath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("file does not exist: %s", filepath)
+	}
+	file, err := os.Open(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+	defer file.Close()
+
+	formats := []*frontmatter.Format{
+		frontmatter.NewFormat(FrontMatterStart, FrontMatterEnd, yaml.Unmarshal),
+	}
+
+	var v map[string]interface{}
+	_, err = frontmatter.Parse(file, &v, formats...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse front matter: %w", err)
+	}
+
+	matter := FrontMatter{}
+	if title, ok := asString(v, "title"); ok {
+		matter.Title = title
+	}
+	if path, ok := asString(v, "path"); ok {
+		matter.Path = path
+	}
+	if createdAt, ok := asSerializedTime(v, "created_at"); ok {
+		matter.CreatedAt = *createdAt
+	}
+	if updatedAt, ok := asSerializedTime(v, "updated_at"); ok {
+		matter.UpdatedAt = *updatedAt
+	}
+	return &matter, nil
+}
+
+func (f *FrontMatter) UpdateMarkdown(filepath string) error {
+	file, err := os.OpenFile(filepath, os.O_RDWR, 0o644)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	formats := []*frontmatter.Format{
+		frontmatter.NewFormat(FrontMatterStart, FrontMatterEnd, yaml.Unmarshal),
+	}
+	var v map[string]interface{}
+	remaining, err := frontmatter.Parse(file, &v, formats...)
+	if err != nil {
+		return fmt.Errorf("failed to parse front matter: %w", err)
+	}
+
+	contents := []byte(f.String())
+	contents = append(contents, remaining...)
+
+	_, err = file.WriteAt(contents, 0)
+	if err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+	return nil
+}
+
+func (f *FrontMatter) String() string {
+	var text string
+	text += fmt.Sprintf("%s\n", FrontMatterStart)
+	text += fmt.Sprintf("title: %s\n", f.Title)
+	text += fmt.Sprintf("path: %s\n", f.Path)
+	text += fmt.Sprintf("created_at: %s\n", f.CreatedAt)
+	text += fmt.Sprintf("updated_at: %s\n", f.UpdatedAt)
+	text += fmt.Sprintf("%s\n", FrontMatterEnd)
+	return text
+}
+
+func asString(m map[string]interface{}, key string) (string, bool) {
+	v, ok := m[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+func asSerializedTime(m map[string]interface{}, key string) (*SerializableTime, bool) {
+	v, ok := m[key]
+	if !ok {
+		return nil, false
+	}
+
+	switch v := v.(type) {
+	case string:
+		st, err := NewSerializableTime(v)
+		return &st, err == nil
+	case time.Time:
+		st := NewSerializableTimeFromTime(v)
+		return &st, true
+	}
+	return nil, false
+}

--- a/src/value_front_matter.go
+++ b/src/value_front_matter.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"os"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/adrg/frontmatter"
@@ -12,27 +14,34 @@ import (
 const (
 	FrontMatterStart = "---"
 	FrontMatterEnd   = "---"
+
+	FrontMatterKeyTitle     = "title"
+	FrontMatterKeyPath      = "path"
+	FrontMatterKeyCreatedAt = "created_at"
+	FrontMatterKeyUpdatedAt = "updated_at"
 )
 
 // A struct that describe the markdown header.
 type FrontMatter struct {
-	Title     string
-	Path      string
-	CreatedAt SerializableTime
-	UpdatedAt SerializableTime
+	Title       string
+	Path        string
+	CreatedAt   SerializableTime
+	UpdatedAt   SerializableTime
+	UnknownTags map[string]interface{}
 }
 
 func NewFrontMatter(title string, path string) *FrontMatter {
 	now := time.Now()
 	return &FrontMatter{
-		Title:     title,
-		Path:      path,
-		CreatedAt: NewSerializableTimeFromTime(now),
-		UpdatedAt: NewSerializableTimeFromTime(now),
+		Title:       title,
+		Path:        path,
+		CreatedAt:   NewSerializableTimeFromTime(now),
+		UpdatedAt:   NewSerializableTimeFromTime(now),
+		UnknownTags: make(map[string]interface{}),
 	}
 }
 
-func NewFrontMatterFromMarkdown(filepath string) (*FrontMatter, error) {
+func NewFrontMatterFromMarkdown(filepath string) (*FrontMatter, error) { //nolint: cyclop
 	if _, err := os.Stat(filepath); os.IsNotExist(err) {
 		return nil, fmt.Errorf("file does not exist: %s", filepath)
 	}
@@ -45,29 +54,42 @@ func NewFrontMatterFromMarkdown(filepath string) (*FrontMatter, error) {
 	formats := []*frontmatter.Format{
 		frontmatter.NewFormat(FrontMatterStart, FrontMatterEnd, yaml.Unmarshal),
 	}
-
-	var v map[string]interface{}
-	_, err = frontmatter.Parse(file, &v, formats...)
+	var kv map[string]string
+	_, err = frontmatter.Parse(file, &kv, formats...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse front matter: %w", err)
 	}
 
-	matter := FrontMatter{}
-	if title, ok := asString(v, "title"); ok {
-		matter.Title = title
+	matter := FrontMatter{
+		UnknownTags: make(map[string]interface{}),
 	}
-	if path, ok := asString(v, "path"); ok {
-		matter.Path = path
-	}
-	if createdAt, ok := asSerializedTime(v, "created_at"); ok {
-		matter.CreatedAt = *createdAt
-	}
-	if updatedAt, ok := asSerializedTime(v, "updated_at"); ok {
-		matter.UpdatedAt = *updatedAt
+	for k, v := range kv {
+		switch strings.ToLower(k) {
+		case FrontMatterKeyTitle:
+			matter.Title = v
+		case FrontMatterKeyPath:
+			matter.Path = v
+		case FrontMatterKeyCreatedAt:
+			if st, err := NewSerializableTime(v); err == nil {
+				matter.CreatedAt = st
+				continue
+			}
+			return nil, fmt.Errorf("failed to parse created_at: %w", err)
+		case FrontMatterKeyUpdatedAt:
+			if st, err := NewSerializableTime(v); err == nil {
+				matter.UpdatedAt = st
+				continue
+			}
+			return nil, fmt.Errorf("failed to parse updated_at: %w", err)
+		default:
+			matter.UnknownTags[k] = v
+		}
 	}
 	return &matter, nil
 }
 
+// UpdateMarkdown updates the front matter of the specified markdown file.
+// It keeps the remaining contents of the file.
 func (f *FrontMatter) UpdateMarkdown(filepath string) error {
 	file, err := os.OpenFile(filepath, os.O_RDWR, 0o644)
 	if err != nil {
@@ -88,7 +110,6 @@ func (f *FrontMatter) UpdateMarkdown(filepath string) error {
 	contents = append(contents, remaining...)
 
 	// Truncate file and rewrite the contents
-
 	if err := file.Truncate(0); err != nil {
 		return fmt.Errorf("failed to truncate file: %w", err)
 	}
@@ -100,38 +121,22 @@ func (f *FrontMatter) UpdateMarkdown(filepath string) error {
 }
 
 func (f *FrontMatter) String() string {
+	// Prepare sorted unknown tag keys
+	sortedKeys := make([]string, 0, len(f.UnknownTags))
+	for k := range f.UnknownTags {
+		sortedKeys = append(sortedKeys, k)
+	}
+	sort.Strings(sortedKeys)
+
 	var text string
 	text += fmt.Sprintf("%s\n", FrontMatterStart)
 	text += fmt.Sprintf("title: %s\n", f.Title)
 	text += fmt.Sprintf("path: %s\n", f.Path)
 	text += fmt.Sprintf("created_at: %s\n", f.CreatedAt)
 	text += fmt.Sprintf("updated_at: %s\n", f.UpdatedAt)
+	for _, k := range sortedKeys {
+		text += fmt.Sprintf("%s: %s\n", k, f.UnknownTags[k])
+	}
 	text += fmt.Sprintf("%s\n", FrontMatterEnd)
 	return text
-}
-
-func asString(m map[string]interface{}, key string) (string, bool) {
-	v, ok := m[key]
-	if !ok {
-		return "", false
-	}
-	s, ok := v.(string)
-	return s, ok
-}
-
-func asSerializedTime(m map[string]interface{}, key string) (*SerializableTime, bool) {
-	v, ok := m[key]
-	if !ok {
-		return nil, false
-	}
-
-	switch v := v.(type) {
-	case string:
-		st, err := NewSerializableTime(v)
-		return &st, err == nil
-	case time.Time:
-		st := NewSerializableTimeFromTime(v)
-		return &st, true
-	}
-	return nil, false
 }

--- a/src/value_front_matter.go
+++ b/src/value_front_matter.go
@@ -21,7 +21,7 @@ const (
 	FrontMatterKeyUpdatedAt = "updated_at"
 )
 
-// A struct that describe the markdown header.
+// A struct that describes the markdown header.
 type FrontMatter struct {
 	Title       string
 	Path        string
@@ -47,7 +47,7 @@ func NewFrontMatterFromMarkdown(filepath string) (*FrontMatter, error) { //nolin
 	}
 	file, err := os.Open(filepath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read file: %w", err)
+		return nil, fmt.Errorf("failed to open file: %w", err)
 	}
 	defer file.Close()
 
@@ -89,7 +89,7 @@ func NewFrontMatterFromMarkdown(filepath string) (*FrontMatter, error) { //nolin
 }
 
 // UpdateMarkdown updates the front matter of the specified markdown file.
-// It keeps the remaining contents of the file.
+// It keeps the remaining contents of the file intact.
 func (f *FrontMatter) UpdateMarkdown(filepath string) error {
 	file, err := os.OpenFile(filepath, os.O_RDWR, 0o644)
 	if err != nil {
@@ -115,7 +115,7 @@ func (f *FrontMatter) UpdateMarkdown(filepath string) error {
 	}
 	_, err = file.WriteAt(contents, 0)
 	if err != nil {
-		return fmt.Errorf("failed to write file: %w", err)
+		return fmt.Errorf("failed to write to file: %w", err)
 	}
 	return nil
 }

--- a/src/value_front_matter.go
+++ b/src/value_front_matter.go
@@ -87,6 +87,11 @@ func (f *FrontMatter) UpdateMarkdown(filepath string) error {
 	contents := []byte(f.String())
 	contents = append(contents, remaining...)
 
+	// Truncate file and rewrite the contents
+
+	if err := file.Truncate(0); err != nil {
+		return fmt.Errorf("failed to truncate file: %w", err)
+	}
 	_, err = file.WriteAt(contents, 0)
 	if err != nil {
 		return fmt.Errorf("failed to write file: %w", err)

--- a/src/value_front_matter_test.go
+++ b/src/value_front_matter_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewFrontMatter(t *testing.T) {
+	title := "Test Title"
+	path := "/test/path"
+	fm := NewFrontMatter(title, path)
+
+	assert.Equal(t, title, fm.Title, "expected title to be %s, got %s", title, fm.Title)
+	assert.Equal(t, path, fm.Path, "expected path to be %s, got %s", path, fm.Path)
+	assert.False(t, fm.CreatedAt.IsNull(), "expected CreatedAt to be set, got null")
+	assert.False(t, fm.UpdatedAt.IsNull(), "expected UpdatedAt to be set, got null")
+}
+
+func TestNewFrontMatterFromMarkdown(t *testing.T) {
+	content := `---
+title: Test Title
+path: /test/path
+created_at: 2023-10-01T00:00:00Z
+updated_at: 2023-10-01T00:00:00Z
+---`
+
+	tmpfile, err := os.CreateTemp("", "test*.md")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.WriteString(content); err != nil {
+		t.Fatalf("failed to write to temp file: %v", err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatalf("failed to close temp file: %v", err)
+	}
+
+	fm, err := NewFrontMatterFromMarkdown(tmpfile.Name())
+	if err != nil {
+		t.Fatalf("failed to create FrontMatter from markdown: %v", err)
+	}
+
+	assert.Equal(t, "Test Title", fm.Title, "expected title 'Test Title', got %s", fm.Title)
+	assert.Equal(t, "/test/path", fm.Path, "expected path '/test/path', got %s", fm.Path)
+
+	expectedTime := SerializableTime("2023-10-01T00:00:00Z")
+	assert.Equal(t, expectedTime, fm.CreatedAt, "expected CreatedAt %v, got %v", expectedTime, fm.CreatedAt)
+	assert.Equal(t, expectedTime, fm.UpdatedAt, "expected UpdatedAt %v, got %v", expectedTime, fm.UpdatedAt)
+}
+
+func TestFrontMatterString(t *testing.T) {
+	fm := NewFrontMatter("Test Title", "/test/path")
+	fm.CreatedAt = NewSerializableTimeFromTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	fm.UpdatedAt = NewSerializableTimeFromTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	expected := `---
+title: Test Title
+path: /test/path
+created_at: 2025-01-01T00:00:00Z
+updated_at: 2025-01-01T00:00:00Z
+---
+`
+
+	if fm.String() != expected {
+		t.Errorf("expected %s, got %s", expected, fm.String())
+	}
+}

--- a/src/value_front_matter_test.go
+++ b/src/value_front_matter_test.go
@@ -15,8 +15,8 @@ func TestNewFrontMatter(t *testing.T) {
 
 	assert.Equal(t, title, fm.Title, "expected title to be %s, got %s", title, fm.Title)
 	assert.Equal(t, path, fm.Path, "expected path to be %s, got %s", path, fm.Path)
-	assert.False(t, fm.CreatedAt.IsNull(), "expected CreatedAt to be set, got null")
-	assert.False(t, fm.UpdatedAt.IsNull(), "expected UpdatedAt to be set, got null")
+	assert.False(t, fm.CreatedAt.IsNull(), "expected CreatedAt to be set, got zero value")
+	assert.False(t, fm.UpdatedAt.IsNull(), "expected UpdatedAt to be set, got zero value")
 }
 
 func TestNewFrontMatterFromMarkdown(t *testing.T) {
@@ -53,7 +53,7 @@ updated_at: 2023-10-01T00:00:00Z
 	assert.Equal(t, expectedTime, fm.UpdatedAt, "expected UpdatedAt %v, got %v", expectedTime, fm.UpdatedAt)
 }
 
-func TestNewFrontMatterFromMarkdownIncludeUnknownTags(t *testing.T) {
+func TestNewFrontMatterFromMarkdownWithUnknownTags(t *testing.T) {
 	content := `---
 title: Test Title
 path: /test/path
@@ -82,10 +82,10 @@ UnknownTag2: "unknown2"
 	}
 
 	assert.Contains(t, fm.UnknownTags, "UnknownTag1", "expected UnknownTag1 to be included in UnknownTags")
-	assert.Contains(t, fm.UnknownTags, "UnknownTag2", "expected UnknownTag1 to be included in UnknownTags")
+	assert.Contains(t, fm.UnknownTags, "UnknownTag2", "expected UnknownTag2 to be included in UnknownTags")
 
-	assert.Equal(t, "unknown1", fm.UnknownTags["UnknownTag1"], "expected UnknownTag1 to be 'unknown', got %s", fm.UnknownTags["UnknownTag1"])
-	assert.Equal(t, "unknown2", fm.UnknownTags["UnknownTag2"], "expected UnknownTag1 to be 'unknown', got %s", fm.UnknownTags["UnknownTag1"])
+	assert.Equal(t, "unknown1", fm.UnknownTags["UnknownTag1"], "expected UnknownTag1 to be 'unknown1', got %s", fm.UnknownTags["UnknownTag1"])
+	assert.Equal(t, "unknown2", fm.UnknownTags["UnknownTag2"], "expected UnknownTag2 to be 'unknown2', got %s", fm.UnknownTags["UnknownTag2"])
 }
 
 func TestFrontMatterString(t *testing.T) {

--- a/src/value_time.go
+++ b/src/value_time.go
@@ -21,6 +21,10 @@ func NewSerializableTime(s string) (SerializableTime, error) {
 	return st, nil
 }
 
+func NewSerializableTimeFromTime(t time.Time) SerializableTime {
+	return SerializableTime(t.Format(time.RFC3339))
+}
+
 // String converts the unix timestamp into a string.
 func (t SerializableTime) String() string {
 	return string(t)

--- a/test.md
+++ b/test.md
@@ -1,0 +1,6 @@
+---
+title: dummy2
+path: test.md
+created_at: 2025-02-23T23:24:13+09:00
+updated_at: 2025-02-23T23:24:13+09:00
+---


### PR DESCRIPTION
This pull request introduces a new `touch` command to manage markdown files, allowing users to create or update files with specific frontmatter fields. It includes the implementation of the command, handling of frontmatter, and corresponding tests.

### New `touch` command implementation:

* [`src/cmd_touch.go`](diffhunk://#diff-87834acb107d9b34ca3b1cba8ad8375e87d0761f81769a9b122341128a450c8cR1-R77): Added the `touch` command which creates or updates markdown files with specified frontmatter fields.
* [`src/main.go`](diffhunk://#diff-9e185f29fa355d7dd8fdd9c9ff1d0723b85206aa7d37c4eec93997005dc291ebR25): Registered the new `touch` command in the main application.

### Frontmatter handling:

* [`src/value_front_matter.go`](diffhunk://#diff-41069ac67a67aee78fa9747e7a4cb829e6ce42804dd8a2c2454fc0b1ef8da26dR1-R142): Implemented the `FrontMatter` struct and methods to create, parse, and update frontmatter in markdown files.
* [`src/value_time.go`](diffhunk://#diff-fab181c278a1a21db509f807f5486fbf51b18e8553303285cd03cfc623bcdb08R24-R27): Added a helper function `NewSerializableTimeFromTime` to convert `time.Time` to `SerializableTime`.

### Testing:

* [`src/value_front_matter_test.go`](diffhunk://#diff-247294341801dcbc7b12ad0da85972082b0a5bfff138c06b467e3c5b6ed822a1R1-R111): Added tests for creating and parsing frontmatter, including handling unknown tags.