### PR TITLE
feat: enhance touch command

### DIFF
--- a/src/cmd_touch_test.go
+++ b/src/cmd_touch_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuteTouchNew(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	path := filepath.Join(tempDir, "test.md")
+	args := TouchArgs{
+		filepath: path,
+		title:    "Test Title",
+		path:     "test-path",
+		debug:    true,
+		noColor:  true,
+		now:      "2025-01-01T00:00:00+09:00",
+	}
+
+	err = executeTouchWrapper(args)
+	require.NoError(t, err)
+
+	// Verify file exists
+	_, err = os.Stat(path)
+	require.NoError(t, err)
+
+	// Verify content
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	expectedContent := `---
+title: "Test Title"
+path: "test-path"
+description: ""
+created_at: "2025-01-01T00:00:00+09:00"
+updated_at: "2025-01-01T00:00:00+09:00"
+---
+`
+	assert.Equal(t, expectedContent, string(content))
+
+	// Then update the markdown.
+	updateArgs := TouchArgs{
+		filepath: path,
+		title:    "Updated Title",
+		path:     "updated-path",
+		debug:    true,
+		noColor:  true,
+		now:      "2025-01-02T00:00:00+09:00",
+	}
+	err = executeTouchWrapper(updateArgs)
+	require.NoError(t, err)
+
+	// Verify content
+	content, err = os.ReadFile(path)
+	require.NoError(t, err)
+
+	expectedContent = `---
+title: "Updated Title"
+path: "updated-path"
+description: ""
+created_at: "2025-01-01T00:00:00+09:00"
+updated_at: "2025-01-02T00:00:00+09:00"
+---
+`
+	assert.Equal(t, expectedContent, string(content))
+}

--- a/src/value_front_matter.go
+++ b/src/value_front_matter.go
@@ -140,11 +140,11 @@ func (f *FrontMatter) String() string {
 
 	var text string
 	text += fmt.Sprintf("%s\n", FrontMatterStart)
-	text += fmt.Sprintf("title: %s\n", f.Title)
-	text += fmt.Sprintf("path: %s\n", f.Path)
-	text += fmt.Sprintf("description: %s\n", f.Description)
-	text += fmt.Sprintf("created_at: %s\n", f.CreatedAt)
-	text += fmt.Sprintf("updated_at: %s\n", f.UpdatedAt)
+	text += fmt.Sprintf("title: \"%s\"\n", f.Title)
+	text += fmt.Sprintf("path: \"%s\"\n", f.Path)
+	text += fmt.Sprintf("description: \"%s\"\n", f.Description)
+	text += fmt.Sprintf("created_at: \"%s\"\n", f.CreatedAt)
+	text += fmt.Sprintf("updated_at: \"%s\"\n", f.UpdatedAt)
 	for _, k := range sortedKeys {
 		text += fmt.Sprintf("%s: %s\n", k, f.UnknownTags[k])
 	}

--- a/src/value_front_matter.go
+++ b/src/value_front_matter.go
@@ -32,14 +32,19 @@ type FrontMatter struct {
 	UnknownTags map[string]interface{}
 }
 
-func NewFrontMatter(title string, path string) *FrontMatter {
-	now := time.Now()
+func NewFrontMatter(title string, path string, now ...time.Time) *FrontMatter {
+	var currentTime time.Time
+	if len(now) > 0 {
+		currentTime = now[0]
+	} else {
+		currentTime = time.Now()
+	}
 	return &FrontMatter{
 		Title:       title,
 		Path:        path,
 		Description: "",
-		CreatedAt:   NewSerializableTimeFromTime(now),
-		UpdatedAt:   NewSerializableTimeFromTime(now),
+		CreatedAt:   NewSerializableTimeFromTime(currentTime),
+		UpdatedAt:   NewSerializableTimeFromTime(currentTime),
 		UnknownTags: make(map[string]interface{}),
 	}
 }

--- a/src/value_front_matter_test.go
+++ b/src/value_front_matter_test.go
@@ -117,6 +117,7 @@ UnknownTag2: "unknown2"
 
 func TestFrontMatterString(t *testing.T) {
 	fm := NewFrontMatter("Test Title", "/test/path")
+
 	fm.Description = "Test Description"
 	fm.CreatedAt = NewSerializableTimeFromTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
 	fm.UpdatedAt = NewSerializableTimeFromTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))

--- a/src/value_front_matter_test.go
+++ b/src/value_front_matter_test.go
@@ -125,11 +125,11 @@ func TestFrontMatterString(t *testing.T) {
 	fm.UnknownTags["UnknownTag2"] = "unknown2"
 
 	expected := `---
-title: Test Title
-path: /test/path
-description: Test Description
-created_at: 2025-01-01T00:00:00Z
-updated_at: 2025-01-01T00:00:00Z
+title: "Test Title"
+path: "/test/path"
+description: "Test Description"
+created_at: "2025-01-01T00:00:00Z"
+updated_at: "2025-01-01T00:00:00Z"
 UnknownTag1: unknown1
 UnknownTag2: unknown2
 ---


### PR DESCRIPTION
This pull request introduces a new feature to the `touch` command, allowing users to specify the current time in RFC3339 format. Additionally, it includes corresponding updates to the `FrontMatter` structure and its handling, as well as new tests to ensure the feature works correctly.

New feature implementation:

* [`src/cmd_touch.go`](diffhunk://#diff-87834acb107d9b34ca3b1cba8ad8375e87d0761f81769a9b122341128a450c8cR22): Added `now` field to `TouchArgs` struct and updated `CreateTouchCmd`, `executeTouchWrapper`, `executeTouchNew`, and `executeTouchUpdate` functions to handle the new `now` parameter. [[1]](diffhunk://#diff-87834acb107d9b34ca3b1cba8ad8375e87d0761f81769a9b122341128a450c8cR22) [[2]](diffhunk://#diff-87834acb107d9b34ca3b1cba8ad8375e87d0761f81769a9b122341128a450c8cR42) [[3]](diffhunk://#diff-87834acb107d9b34ca3b1cba8ad8375e87d0761f81769a9b122341128a450c8cR58-R65) [[4]](diffhunk://#diff-87834acb107d9b34ca3b1cba8ad8375e87d0761f81769a9b122341128a450c8cL83-R98) [[5]](diffhunk://#diff-87834acb107d9b34ca3b1cba8ad8375e87d0761f81769a9b122341128a450c8cL105-R141)

Updates to `FrontMatter` structure:

* [`src/value_front_matter.go`](diffhunk://#diff-41069ac67a67aee78fa9747e7a4cb829e6ce42804dd8a2c2454fc0b1ef8da26dL35-R47): Modified `NewFrontMatter` function to accept an optional `now` parameter and updated `String` method to format fields with quotes. [[1]](diffhunk://#diff-41069ac67a67aee78fa9747e7a4cb829e6ce42804dd8a2c2454fc0b1ef8da26dL35-R47) [[2]](diffhunk://#diff-41069ac67a67aee78fa9747e7a4cb829e6ce42804dd8a2c2454fc0b1ef8da26dL138-R147)

Testing:

* [`src/cmd_touch_test.go`](diffhunk://#diff-bdbd5e39142a9a601c5630a39b550cc41513a28bb2bde9de79a4181fa6866524R1-R73): Added new tests for the `touch` command to verify the correct handling of the `now` parameter and the proper formatting of the `FrontMatter` fields.

The changes ensure that users can specify a custom current time when using the `touch` command, and that the `FrontMatter` is correctly generated and updated with the specified time.