### PR TITLE
feat: add a repository field

### DIFF
--- a/src/value_config_test.go
+++ b/src/value_config_test.go
@@ -29,6 +29,7 @@ const TestCaseForDetailCheckMarkdown = `
 version: 1
 project:
   name: "Test Project"
+  repository: "https://github.com/mkei29/dodo-cli"
 pages:
   - markdown: "README1.md"
     path: "readme1"
@@ -57,6 +58,8 @@ func TestParseConfigDetailsMarkdown(t *testing.T) {
 
 	// Check metadata
 	assert.Equal(t, "1", conf.Version)
+	assert.Equal(t, "Test Project", conf.Project.Name)
+	assert.Equal(t, "https://github.com/mkei29/dodo-cli", conf.Project.Repository)
 
 	// Check README1
 	assert.Equal(t, "README1.md", conf.Pages[0].Markdown)
@@ -196,6 +199,17 @@ project:
 	version: "1.0.0"
 pages:
 	- markdown: "README2.md"
+`
+
+const TestCaseParseInvalidRepositoryURL = `
+version: 1
+project:
+  name: "Test Project"
+	repository: "xxxx",
+pages:
+  - markdown: "README2.md"
+    path: "readme2"
+    title: "README2"
 `
 
 const TestCaseWithUnknownField = `
@@ -370,6 +384,11 @@ func TestParseConfig(t *testing.T) {
 		{
 			name:     "invalid config: empty project name",
 			input:    TestCaseWithEmptyProjectName,
+			expected: false,
+		},
+		{
+			name:     "invalid config: invalid repository URL",
+			input:    TestCaseParseInvalidRepositoryURL,
 			expected: false,
 		},
 		{

--- a/src/value_metadata.go
+++ b/src/value_metadata.go
@@ -26,17 +26,15 @@ type MetadataProject struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	Version     string `json:"version"`
+	Repository  string `json:"repository"`
 }
 
 func NewMetadataProjectFromConfig(c *Config) MetadataProject {
-	name := c.Project.Name
-	description := c.Project.Description
-	version := c.Project.Version
-
 	return MetadataProject{
-		Name:        name,
-		Description: description,
-		Version:     version,
+		Name:        c.Project.Name,
+		Description: c.Project.Description,
+		Version:     c.Project.Version,
+		Repository:  c.Project.Repository,
 	}
 }
 


### PR DESCRIPTION
This pull request introduces several changes to the configuration and metadata handling in the project. The main focus is on adding support for a `Repository` field in the configuration and ensuring its validation.

### Configuration Enhancements:
* Added a `Repository` field to the `ConfigProject` struct in `src/value_config.go` to store the repository URL.
* Updated the `parseConfigProject` function to handle the new `repository` field, including validation to ensure it is a valid URL.
* Imported the `net/url` package in `src/value_config.go` to facilitate URL validation.

### Testing Enhancements:
* Added test cases in `src/value_config_test.go` to verify the correct parsing of the `repository` field and to check for invalid URLs. [[1]](diffhunk://#diff-eb199e025772e1b3949f4f2b76b296397fef45bf34b7b9e39fb96841a9352a62R32) [[2]](diffhunk://#diff-eb199e025772e1b3949f4f2b76b296397fef45bf34b7b9e39fb96841a9352a62R61-R62) [[3]](diffhunk://#diff-eb199e025772e1b3949f4f2b76b296397fef45bf34b7b9e39fb96841a9352a62R204-R214) [[4]](diffhunk://#diff-eb199e025772e1b3949f4f2b76b296397fef45bf34b7b9e39fb96841a9352a62R389-R393)

### Metadata Enhancements:
* Updated the `MetadataProject` struct in `src/value_metadata.go` to include the `Repository` field and modified the `NewMetadataProjectFromConfig` function to populate this field.